### PR TITLE
shorten build time by moving requirements to earlier layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,12 @@ LABEL github="https://github.com/dolevf/Damn-Vulnerable-GraphQL-Application"
 LABEL maintainer="dolev@lethalbit.com"
 
 ARG TARGET_FOLDER=/opt/dvga
+WORKDIR $TARGET_FOLDER/
 
 RUN apk add --update curl
+
+COPY requirements.txt /opt/dvga/
+RUN pip install -r requirements.txt
 
 ADD core /opt/dvga/core
 ADD db /opt/dvga/db
@@ -15,13 +19,9 @@ ADD templates /opt/dvga/templates
 
 COPY app.py /opt/dvga
 COPY config.py /opt/dvga
-COPY requirements.txt /opt/dvga/
 COPY setup.py /opt/dvga/
 COPY version.py /opt/dvga/
 
-WORKDIR $TARGET_FOLDER/
-
-RUN pip install -r requirements.txt
 RUN python setup.py
 
 EXPOSE 5000/tcp


### PR DESCRIPTION
By moving requirements to an earlier layer we get the benefit of not invalidating the cache as often so we should see a much faster on average build time.