### PR TITLE
Persist Difficulty Mode to DB 

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,17 +1,13 @@
 import config
 import sys
+import os
 
-from os import urandom
-from core.helpers import initialize
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from flask_sockets import Sockets
-from graphql_ws.gevent import  GeventSubscriptionServer
-import logging
-import logging.handlers as handlers
 
 app = Flask(__name__, static_folder="static/")
-app.secret_key = urandom(24)
+app.secret_key = os.urandom(24)
 app.config["SQLALCHEMY_DATABASE_URI"] = config.SQLALCHEMY_DATABASE_URI
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = config.SQLALCHEMY_TRACK_MODIFICATIONS
 app.config["UPLOAD_FOLDER"] = config.WEB_UPLOADDIR
@@ -26,7 +22,7 @@ db = SQLAlchemy(app)
 if __name__ == '__main__':
   sys.setrecursionlimit(100000)
 
-  initialize()
+  os.popen("python3 setup.py").read()
 
   from core.views import *
   from gevent import pywsgi

--- a/core/helpers.py
+++ b/core/helpers.py
@@ -4,6 +4,8 @@ import base64
 import uuid
 import os
 
+from core.models import ServerMode
+
 def run_cmd(cmd):
   return os.popen(cmd).read()
 
@@ -26,16 +28,12 @@ def save_file(filename, text):
   return text
 
 def is_level_easy():
-  return session.get('difficulty') == 'easy'
+  mode = ServerMode.query.one()
+  return mode.hardened == False
 
 def is_level_hard():
-  return session.get('difficulty') == 'hard'
+  mode = ServerMode.query.one()
+  return mode.hardened == True
 
 def set_mode(mode):
-  session['difficulty'] = mode
-
-def get_opname(operation):
-  try:
-    return operation.name.value
-  except:
-    return "No Operation"
+  mode = ServerMode.set_mode(mode)

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -73,7 +73,10 @@ class OpNameProtectionMiddleware(object):
     if helpers.is_level_easy():
       return next(root, info, **kwargs)
 
-    opname = helpers.get_opname(info.operation)
+    try:
+      opname = info.operation.name.value
+    except:
+      opname = "No Operation"
 
     if opname != 'No Operation' and not security.operation_name_allowed(opname):
       raise werkzeug.exceptions.SecurityError('Operation Name "{}" is not allowed.'.format(opname))

--- a/core/models.py
+++ b/core/models.py
@@ -1,11 +1,7 @@
 import datetime
 
 from app import db
-from core import helpers
-from sqlalchemy import event
 from graphql import parse
-
-from rx import Observable
 
 # Models
 class User(db.Model):
@@ -35,7 +31,10 @@ class Audit(db.Model):
     gql_operation = None
 
     if not operation_type:
-      gql_operation = helpers.get_opname(info.operation)
+      try:
+        gql_operation = info.operation.name.value
+      except:
+        gql_operation = "No Operation"
       
       if info.context.json:
         gql_query = info.context.json.get("query")
@@ -79,6 +78,24 @@ class Paste(db.Model):
   @classmethod
   def create_paste(cls, **kw):
     obj = cls(**kw)
+    db.session.add(obj)
+    db.session.commit()
+
+    return obj
+
+class ServerMode(db.Model):
+  __tablename__ = 'servermode'
+  id = db.Column(db.Integer, primary_key=True)
+  hardened = db.Column(db.Boolean, default=False)
+  
+  @classmethod
+  def set_mode(cls, mode):
+    obj = ServerMode.query.one()
+    if mode == 'easy':
+      obj.hardened = False
+    else:
+      obj.hardened = True
+      
     db.session.add(obj)
     db.session.commit()
 

--- a/core/views.py
+++ b/core/views.py
@@ -5,7 +5,7 @@ from core.directives import *
 from db.solutions import solutions as list_of_solutions
 from rx.subjects import Subject
 
-from sqlalchemy import create_engine, text
+from sqlalchemy import text
 from flask import (
   request,
   render_template,
@@ -402,8 +402,18 @@ def difficulty(level):
 
 
 @app.context_processor
+def get_difficulty():
+  level = None
+  if helpers.is_level_easy():
+    level = 'easy'
+  else:
+    level = 'hard'
+  return dict(difficulty=level)
+  
+@app.context_processor
 def get_server_info():
   return dict(version=VERSION, host=WEB_HOST, port=WEB_PORT)
+
 
 @app.before_request
 def set_difficulty():
@@ -412,9 +422,6 @@ def set_difficulty():
     if mode_header == 'Expert':
       helpers.set_mode('hard')
     else:
-      helpers.set_mode('easy')
-  else:
-    if session.get('difficulty') == None:
       helpers.set_mode('easy')
 
 schema = graphene.Schema(query=Query, mutation=Mutations, subscription=Subscription, directives=[ShowNetworkDirective, SkipDirective, DeprecatedDirective])

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,14 @@
 import sys
 import os
 import shutil
+from xmlrpc.client import Server
 import config
 import random
 
 from ipaddress import IPv4Network
 
 from app import db
-from core.models import Paste, Owner, User
+from core.models import Paste, Owner, User, ServerMode
 
 from db.agents import agents
 from db.owners import owners
@@ -89,6 +90,10 @@ def pump_db():
 
     db.session.add(owner)
     db.session.add(paste)
+
+  mode = ServerMode()
+  mode.hardened = False
+  db.session.add(mode)
 
   db.session.commit()
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import sys
 import os
 import shutil
-from xmlrpc.client import Server
 import config
 import random
 

--- a/templates/partials/base.html
+++ b/templates/partials/base.html
@@ -50,12 +50,9 @@
             exampleSocket.send(JSON.stringify(graphqlMsg));
         };
 
-        var PASTE_UPDATES = {};
-
         exampleSocket.onmessage = function (event) {
           data = JSON.parse(event.data)
           paste = data.payload.data.paste
-
 
           var pasteHTML = `<div class="card-header">
               <i class="fa fa-paste"></i> &nbsp; ${paste.title}

--- a/templates/partials/navbar.html
+++ b/templates/partials/navbar.html
@@ -24,9 +24,9 @@
             <i class="fa fa-cubes"></i>
           </a>
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="difficultyDropDown">
-            <a class="dropdown-item" href="/difficulty/easy">Beginner {% if session['difficulty'] == "easy" %} <i
+            <a class="dropdown-item" href="/difficulty/easy">Beginner {% if difficulty == "easy" %} <i
                 class="fa fa-check"></i> {% endif %}</a>
-            <a class="dropdown-item" href="/difficulty/hard">Expert (Hardened) {% if session['difficulty'] == "hard" %} <i
+            <a class="dropdown-item" href="/difficulty/hard">Expert (Hardened) {% if difficulty == "hard" %} <i
                 class="fa fa-check"></i> {% endif %}</a>
           </div>
         </li>

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.0.0'
+VERSION = '2.0.1'


### PR DESCRIPTION
**What**
1. Difficulty mode selection in UI is now persisted to SQLAlchemy and will be global to all headless and non-headless clients.
2. Passing the `X-DVGA-MODE` header will automatically change the mode globally too.