### PR TITLE
Handle errors on missing JSON in me query

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -1,5 +1,7 @@
 import graphene
 
+from graphql import GraphQLError
+
 from core import (
   security,
   helpers,
@@ -282,6 +284,10 @@ class Query(graphene.ObjectType):
     Audit.create_audit_entry(info)
 
     identity = get_identity(token)
+
+    if info.context.json == None:
+      raise GraphQLError("JSON payload was not found.")
+
     info.context.json['identity'] = identity
 
     query = UserObject.get_query(info)


### PR DESCRIPTION
Raise a GraphQLError with a custom message when a GET request is sent to the `me` resolver.