### PR TITLE
feat: add matrix to test job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,12 +13,25 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-22.04
+          - ubuntu-20.04
+        pyver:
+          - '3.6'
+          - '3.8'
+          - '3.9'
+        exclude:
+          - os: ubuntu-22.04
+            pyver: 3.6
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.6'
+          python-version: ${{ matrix.pyver }}
           cache: 'pip'
       - run: pip install -r requirements.txt
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,7 @@ jobs:
           - ubuntu-20.04
         pyver:
           - '3.6'
+          - '3.7'
           - '3.8'
           - '3.9'
         exclude:


### PR DESCRIPTION
Python 3.6 is unsupported. DVGA tests should be run against supported Python versions and a recent Ubuntu release.

Add a matrix to the test job to ensure compatability with supported Python and Ubuntu versions.