### PR TITLE
feat: Add Dockerfile for ARM-based Macs

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,35 @@
+FROM python:3.9-alpine
+
+LABEL description="Damn Vulnerable GraphQL Application"
+LABEL github="https://github.com/dolevf/Damn-Vulnerable-GraphQL-Application"
+LABEL maintainers="Dolev Farhi & Connor McKinnon & Nick Aleks"
+
+ARG TARGET_FOLDER=/opt/dvga
+WORKDIR $TARGET_FOLDER/
+
+RUN apk add --virtual build-deps file make curl gcc musl-dev libffi-dev g++
+
+RUN adduser -D dvga
+RUN chown dvga. $TARGET_FOLDER/
+USER dvga
+
+RUN python -m venv venv
+RUN source venv/bin/activate
+RUN pip3 install --upgrade pip --no-warn-script-location --disable-pip-version-check
+
+ADD --chown=dvga:dvga core /opt/dvga/core
+ADD --chown=dvga:dvga db /opt/dvga/db
+ADD --chown=dvga:dvga static /opt/dvga/static
+ADD --chown=dvga:dvga templates /opt/dvga/templates
+
+COPY --chown=dvga:dvga app.py /opt/dvga
+COPY --chown=dvga:dvga config.py /opt/dvga
+COPY --chown=dvga:dvga setup.py /opt/dvga/
+COPY --chown=dvga:dvga version.py /opt/dvga/
+COPY --chown=dvga:dvga requirements.txt /opt/dvga/
+
+RUN pip3 install -r requirements.txt --user --no-warn-script-location
+RUN python setup.py
+
+EXPOSE 5013/tcp
+CMD ["python", "app.py"]

--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ See [requirements.txt](requirements.txt) for dependencies.
 
 `docker build -t dvga .`
 
+#### ARM-based Macs
+
+`docker build -t dvga -f Dockerfile.arm64 .`
+
 ### Create a container from the image
 
 `docker run -d -t -p 5013:5013 -e WEB_HOST=0.0.0.0 --name dvga dvga`


### PR DESCRIPTION
Although gevent recently began to support arm64 binary wheels, they are only supported on manylinux2014-compatible systems - which Alpine is not. (Per: https://www.gevent.org/install.html) As specified in the gevent install docs, when a binary wheel is not available, pip will fall back on building from source.

Add a Dockerfile for ARM-based Macs that includes the dependencies for building gevent.

Credit to @st0w for the change.

Closes #74